### PR TITLE
Remove spurious dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -215,11 +215,6 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "bindings": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
-    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,5 @@
     "should": "^13.2.1",
     "standard": "^11.0.1",
     "typescript": "^2.9.2"
-  },
-  "dependencies": {
-    "bindings": "^1.3.0"
   }
 }


### PR DESCRIPTION
With the removal of the javascript binding, `bindings` is no longer necessary.