### PR TITLE
Pass the correct number of arguments to seek and length

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -5,15 +5,22 @@
             'sources': [
                 'src/main.c'
             ],
-            'cflags': [
-                '-std=c11'
-            ],
-            'link_settings': {
-                'libraries': [
-                    '-lavcodec.58',
-                    '-lavformat.58'
-                ]
-            }
+            'conditions': [
+                ['OS in "linux mac"', {
+                    'cflags!': [ '-Wno-unused-parameter' ],
+                    'link_settings': {
+                        'libraries': [
+                            '-lavcodec.58',
+                            '-lavformat.58'
+                        ]
+                    }
+                }],
+                ['OS=="mac"', {
+                    'xcode_settings': {
+                        'WARNING_CFLAGS!': [ '-Wno-unused-parameter' ]
+                    }
+                }]
+            ]
         }
     ]
 }

--- a/src/main.c
+++ b/src/main.c
@@ -163,7 +163,7 @@ static int64_t seek_or_len(void *opaque, int64_t offset, int whence) {
 
     napi_value fn;
     TRYRET_NAPI(fn_env->env, napi_get_reference_value(fn_env->env, fn_ref, &fn), AVERROR_EXTERNAL);
-    TRYRET_NAPI(fn_env->env, napi_call_function(fn_env->env, NULL, fn, 2, argv, &fn), AVERROR_EXTERNAL);
+    TRYRET_NAPI(fn_env->env, napi_call_function(fn_env->env, NULL, fn, argc, argv, &fn), AVERROR_EXTERNAL);
     if (!check_type(fn_env->env, fn, napi_number)) {
         THROW_TYPE(fn_env->env, "Seek or length did not return number");
         return AVERROR_EXTERNAL;

--- a/src/main.c
+++ b/src/main.c
@@ -55,7 +55,7 @@ typedef struct allocated_objects__ {
 } *allocated_objects;
 typedef struct fn_env__ {
     struct allocated_objects__ allocations;
-    napi_env env;
+    napi_env env;   // make the hacky assumption we only ever get called in response to js
     napi_ref close;
     napi_ref read;
     napi_ref seek;


### PR DESCRIPTION
When refactoring, introduced an issue where length was passed 2 pieces of uninitialized memory. Resolved by using the argc variable introduced during refactoring.